### PR TITLE
Fix: print_output=False not honoured for non-SCF tasks (e.g. DOS)

### DIFF
--- a/src/ase2sprkkr/common/process_output_reader.py
+++ b/src/ase2sprkkr/common/process_output_reader.py
@@ -7,6 +7,7 @@ import asyncio
 import functools
 import subprocess
 import os
+import sys
 import numpy as np
 from .decorators import maybeclassmethod
 
@@ -123,7 +124,8 @@ class ProcessOutputReader:
           line=await stderr.readline()
           if not line:
              return
-          print(line.decode('utf8'))
+          if self.print_output is True:
+             print(line.decode('utf8'), end='', file=sys.stderr)
 
   async def read_output(self, stdout, *args):
       raise NotImplementedError('Please, redefine BaseProcess.read_output coroutine')


### PR DESCRIPTION
## Summary

`print_output=False` did not suppress on-screen output for tasks that use the generic output reader (DOS, and any other task without a dedicated reader). It worked for SCF, so the behaviour was inconsistent across tasks. This PR makes `read_error` respect `print_output`, matching the existing stdout path.

## Problem

`ProcessOutputReader.read_error` read the executable's stderr line by line and called `print(...)` unconditionally — with no reference to `print_output`, and to stdout rather than stderr. SCF appeared unaffected because `kkrscf` is quiet on stderr and `ScfOutputReader` curates its stdout; tasks routed through `DefaultOutputReader` (e.g. DOS via `kkrgen`) printed the executable's full stderr to the screen even with `print_output=False`.

The stdout side was already gated correctly (`if self.print_output is True`), so the inconsistency was confined to this one routine.

## Change

- Gate the stderr echo on `print_output`, mirroring the stdout path (raw streams are echoed only under `print_output=True`).
- Send the echo to `sys.stderr` instead of stdout.
- Drop the duplicate newline (the line already carries one), matching
  the `end=''` used on the stdout path.

Failures remain visible regardless of `print_output`: a non-zero return code still raises `ValueError`, and both streams are written to the `.out` file via the existing `replace_feed_data` wrapper.

## Behaviour notes

- Under the default `print_output='info'`, raw stderr is no longer echoed; only the curated info lines are printed. This matches the documented meaning of `'info'` ("brief information about iterations") and quiets noisy generic-reader tasks by default.
- stderr content now appears on stderr rather than stdout, so it can be redirected with `2>`.

If it is preferred to keep raw stderr visible in `'info'` mode, the guard can be changed from `is True` to a plain truthiness check so that only `False` is affected.

## Out of scope

Two related spots also ignore `print_output`, left for a separate change to keep this focused: `read_error` discards the stderr lines (so `ValueError.error` is always empty — accumulating them would make failures legible when printing is off), and `parse_files` in `sprkkr_output_reader.py` prints ten lines before raising on a malformed header.